### PR TITLE
security fix: use strict policy to prevent imagetragick vulnerability exploitation

### DIFF
--- a/imagemagick.js
+++ b/imagemagick.js
@@ -21,7 +21,14 @@ function exec2(file, args /*, options, callback */) {
     }
   }
 
-  var child = childproc.spawn(file, args);
+  var env = Object.create(process.env);
+  if (env.MAGICK_CONFIGURE_PATH) {
+    console.warn('warn: MAGICK_CONFIGURE_PATH is already defined!');
+  }
+
+  env.MAGICK_CONFIGURE_PATH = __dirname + '/policy';
+
+  var child = childproc.spawn(file, args,  { env: env });
   var killed = false;
   var timedOut = false;
 

--- a/policy/policy.xml
+++ b/policy/policy.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Disable the vulnerable ImageMagick coders as suggested
+  https://imagetragick.com/#policy
+-->
+<policymap>
+  <policy domain="coder" rights="none" pattern="EPHEMERAL" />
+  <policy domain="coder" rights="none" pattern="URL" />
+  <policy domain="coder" rights="none" pattern="HTTPS" />
+  <policy domain="coder" rights="none" pattern="MVG" />
+  <policy domain="coder" rights="none" pattern="MSL" />
+  <policy domain="coder" rights="none" pattern="TEXT" />
+  <policy domain="coder" rights="none" pattern="SHOW" />
+  <policy domain="coder" rights="none" pattern="WIN" />
+  <policy domain="coder" rights="none" pattern="PLT" />
+</policymap>

--- a/sample-images/imagetragick_rce1.png
+++ b/sample-images/imagetragick_rce1.png
@@ -1,0 +1,4 @@
+push graphic-context
+viewbox 0 0 640 480
+fill 'url(https://tinyurl.com/favorites.gif"|touch "rce1)'
+pop graphic-context

--- a/test-tragick.js
+++ b/test-tragick.js
@@ -1,0 +1,25 @@
+var fs = require('fs');
+var im = require('./imagemagick');
+
+// this is a malicious png file (actually an mvg) demonstrating
+// one of the imagetragick vulnerabilities (CVE-2016–3714).
+// when passed to a vulnerable version of imagemagick's `identify` or
+// `convert` command line tool, it will create a file (touch) named `rce1`.
+// for more information see: https://imagetragick.com/
+var path = __dirname + '/sample-images/imagetragick_rce1.png';
+var pocFile = __dirname + '/rce1';
+
+fs.unlink(pocFile, function () {
+  im.identify(path, function (err, features) {
+    fs.exists(pocFile, function (exists) {
+      if (exists) {
+        console.log('Bad news! Exploit worked!');
+        fs.unlink(pocFile, function () {
+          console.log('Cleaned up!');
+        });
+      } else {
+        console.log('Good news! Exploit failed!');
+      }
+    });
+  });
+});


### PR DESCRIPTION
Using the provided policy.xml file prevents the exploitation of the following vulnerabilities in ImageMagick (https://imagetragick.com/)
CVE-2016–3714
CVE-2016-3718
CVE-2016-3715
CVE-2016-3716
CVE-2016-3717
